### PR TITLE
Propagate internal call errors through the journal

### DIFF
--- a/core.proto
+++ b/core.proto
@@ -18,8 +18,15 @@ message MethodIdentifier {
   string method = 2;
 }
 
-// Definition of a failed result of a call
-message FailedCallResult {
-  int32 code = 1;
-  string message = 2;
+// Definition of a internal or external call result
+message CallResult {
+  message Failure {
+    int32 code = 1;
+    string message = 2;
+  }
+
+  oneof value {
+    bytes success = 1;
+    Failure failure = 2;
+  };
 }

--- a/protocol.proto
+++ b/protocol.proto
@@ -52,17 +52,16 @@ message JournalEntry {
     bytes parameter = 4;
 
     // This is filled only and only if Status == DONE
-    oneof result {
-      bytes success = 5;
-      restate.core.FailedCallResult failure = 6;
-    };
+    restate.core.CallResult result = 5;
   }
 
   // ExternalCallEntry describes a call to an external service,
   // which result will asynchronously wake up the function at a later point in time.
   message ExternalCallEntry {
     // This is filled only and only if Status == DONE
-    bytes result = 3;
+    // Note that failure case here is filled by the sdk,
+    // iff something goes wrong when executing the code that invokes the external system
+    restate.core.CallResult result = 5;
   }
 
   message UserSideEffectEntry {


### PR DESCRIPTION
Part of https://github.com/restatedev/runtime/issues/127, this is the contract part that propagates failures of internal calls